### PR TITLE
Prevent release from PR

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -212,6 +212,7 @@ jobs:
           else
             echo "Not a release, skipping publish"
           fi
+        if: ${{ github.event_name == 'push' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Prevent GH Actions from publishing to NPM in pull requests. This PR makes sure we don't get accidental releases during the development.